### PR TITLE
enable the glusterd by default when the package is installed on suse11

### DIFF
--- a/glusterfs.spec
+++ b/glusterfs.spec
@@ -204,7 +204,7 @@ chmod u-s "$b/%_bindir/fusermount-glusterfs"
 %if 0%{?suse_version} >= 1210
 %service_add_post glusterd.service
 %else
-%fillup_and_insserv -f glusterd
+%fillup_and_insserv -f -y glusterd
 %endif
 
 %preun


### PR DESCRIPTION
add -y to enable the glusterd init-script by default if the package is installed for the first time on suse11